### PR TITLE
Changing isatty() declaration to unistd.h include

### DIFF
--- a/src/macros.h
+++ b/src/macros.h
@@ -531,7 +531,7 @@ do {  char *_subschar_macro_ch = (s);                                    \
 /* isatty() is not POSIX                                                */
 #ifdef __unix
 #  if defined(_POSIX_SOURCE) || !defined(_SVR4_SOURCE)
-      extern int isatty(int);
+      #include <unistd.h>
 #  endif
 #endif
 


### PR DESCRIPTION
This change has been discussed with Andrew Martin over emails (with
Craig Porter cc'ed). It should have no effect on code that already
compiles correctly.

Motivation: the hard-coded declaration of isatty() slightly differs from
the official one, which conditionally adds a throw specification if
being compiled under a C++ compiler. This sometimes breaks the compile
when I include, say "pdb.h", from C++ with:

```
extern "C" {
  #include "bioplib/trunk/pdb.h"
}
```

...because the C++ compiler has already seen a definition of isatty()
with a throw specification elsewhere and barfs on seeing a conflicting
declaration.
